### PR TITLE
Basic route changes in prep for internal instance

### DIFF
--- a/server/src/lib/model/db.ts
+++ b/server/src/lib/model/db.ts
@@ -483,8 +483,8 @@ export default class DB {
 
     await this.mysql.query(
       `
-        INSERT INTO user_clients (client_id, auth_token, username)
-        VALUES (?, ?, '')
+        INSERT INTO user_clients (client_id, auth_token, username, visible)
+        VALUES (?, ?, '', 1)
         ON DUPLICATE KEY UPDATE
           auth_token = IF(auth_token IS NULL, VALUES(auth_token), auth_token)
       `,

--- a/web/src/components/layout/content.tsx
+++ b/web/src/components/layout/content.tsx
@@ -45,16 +45,6 @@ export default function Content({ location }: { location: any }) {
           />
           <Route
             exact
-            path={toLocaleRoute(URLS.DATA)}
-            render={() => <Redirect to={toLocaleRoute(URLS.DATASETS)} />}
-          />
-          <Route
-            exact
-            path={toLocaleRoute(URLS.DATASETS)}
-            component={DatasetsPage}
-          />
-          <Route
-            exact
             path={toLocaleRoute('/login-failure')}
             component={LoginFailure}
           />
@@ -76,7 +66,7 @@ export default function Content({ location }: { location: any }) {
             path={toLocaleRoute(URLS.DASHBOARD)}
             component={DashboardPage}
           />
-          {[URLS.CHALLENGE, URLS.STATS, URLS.GOALS, URLS.AWARDS].map(path => (
+          {[URLS.STATS].map(path => (
             <Route
               key={path}
               exact
@@ -93,8 +83,6 @@ export default function Content({ location }: { location: any }) {
               <Redirect to={toLocaleRoute(URLS.DASHBOARD + '/' + URLS.GOALS)} />
             )}
           />
-          <Route exact path={toLocaleRoute(URLS.FAQ)} component={FAQPage} />
-          <Route exact path={toLocaleRoute(URLS.ABOUT)} component={AboutPage} />
           <Route
             exact
             path={toLocaleRoute(URLS.PRIVACY)}

--- a/web/src/components/layout/footer.css
+++ b/web/src/components/layout/footer.css
@@ -94,7 +94,7 @@ footer {
             flex-direction: column;
             min-width: 9rem;
             margin-right: 8rem;
-            margin-top: 0;
+            margin-top: 2rem;
         }
 
         & .main-logo {

--- a/web/src/components/layout/footer.tsx
+++ b/web/src/components/layout/footer.tsx
@@ -25,26 +25,6 @@ export default React.memo(() => {
   const [locale] = useLocale();
   return (
     <footer>
-      <div id="help-links">
-        <LocaleLink to={URLS.FAQ} onClick={() => trackNav('faq', locale)}>
-          <SupportIcon />
-          <Localized id="faq">
-            <div />
-          </Localized>
-        </LocaleLink>
-        <div className="divider" />
-        <DiscourseLink id="discourse">
-          <DiscourseIcon />
-          <div>Discourse</div>
-        </DiscourseLink>
-        <div className="divider" />
-        <ContactLink>
-          <ContactIcon />
-          <Localized id="contact">
-            <div />
-          </Localized>
-        </ContactLink>
-      </div>
       <div id="moz-links">
         <div className="logo-container">
           <Logo reverse />
@@ -63,39 +43,6 @@ export default React.memo(() => {
               <span />
             </Localized>
           </p>
-        </div>
-        <div className="divider-bottom" />
-        <div className="links">
-          <div>
-            <LocalizedLocaleLink id="privacy" to={URLS.PRIVACY} />
-            <LocalizedLocaleLink id="terms" to={URLS.TERMS} />
-            <Localized id="cookies">
-              <a
-                target="_blank"
-                href="https://www.mozilla.org/en-US/privacy/websites/#cookies"
-                rel="noopener noreferrer"
-              />
-            </Localized>
-          </div>
-          <div className="divider-vertical"/>
-          <div>
-            <LocalizedLocaleLink id="faq" to={URLS.FAQ} />
-            <GitHubLink>GitHub</GitHubLink>
-          </div>
-        </div>
-
-        <div id="sharing">
-          <Localized id="share-title">
-            <span className="title" />
-          </Localized>
-
-          <div className="icons">
-            <ShareButtons />
-          </div>
-        </div>
-
-        <div id="email-subscription">
-          <SubscribeNewsletter />
         </div>
 
         <Localized id="back-top">

--- a/web/src/components/layout/nav.tsx
+++ b/web/src/components/layout/nav.tsx
@@ -28,11 +28,11 @@ export default ({ children, ...props }: { [key: string]: any }) => (
   <nav {...props} className="nav-list">
     <div className="nav-links">
       <ContributableLocaleLock>
-        <LocalizedNavLink id="contribute" to={URLS.SPEAK} />
+      <LocalizedNavLink id="listen" to={URLS.LISTEN} />
+        <LocalizedNavLink id="speak" to={URLS.SPEAK} />
       </ContributableLocaleLock>
-      <LocalizedNavLink id="datasets" to={URLS.DATASETS} />
+      <LocalizedNavLink id="dashboard" to={URLS.DASHBOARD} />
       <LocalizedNavLink id="languages" to={URLS.LANGUAGES} />
-      <LocalizedNavLink id="about" to={URLS.ABOUT} />
     </div>
     {children}
   </nav>

--- a/web/src/components/pages/contribution/contribution.tsx
+++ b/web/src/components/pages/contribution/contribution.tsx
@@ -148,6 +148,15 @@ class ContributionPage extends React.Component<Props, State> {
     );
   }
 
+  constructor(props: Props) {
+    super(props);
+    const { user } = this.props;
+    if (!user.account) {
+      sessionStorage.setItem('redirectURL', location.pathname);
+      window.location.href = '/login';
+    }
+  }
+
   componentDidMount() {
     this.startWaving();
     window.addEventListener('keydown', this.handleKeyDown);

--- a/web/src/components/pages/home/home.tsx
+++ b/web/src/components/pages/home/home.tsx
@@ -132,61 +132,6 @@ export default function HomePage() {
         <ClipsStats.Root />
         <VoiceStats />
       </div>
-
-      {user.account ? (
-        <section className="contribute-section">
-          <div className="mars-container">
-            <img src="/img/mars.svg" alt="Mars" />
-          </div>
-          <div className="cta">
-            <ContributableLocaleLock
-              render={({ isContributable }: any) =>
-                isContributable ? (
-                  <>
-                    <RecordLink
-                      onClick={() => trackHome('speak-mars', locale)}
-                    />
-                    <Localized id="ready-to-record">
-                      <h1 />
-                    </Localized>
-                  </>
-                ) : (
-                  <>
-                    <Localized id="request-language-text">
-                      <h1 />
-                    </Localized>
-                    <div style={{ width: '100%' }} />
-                    <Localized id="request-language-button">
-                      <LinkButton
-                        type="button"
-                        className="request-language"
-                        blank
-                        href="https://github.com/mozilla/common-voice/blob/main/docs/LANGUAGE.md"
-                      />
-                    </Localized>
-                  </>
-                )
-              }
-            />
-          </div>
-        </section>
-      ) : (
-        <RegisterSection marsSrc="/img/mars.svg">
-          <Localized id="help-make-dataset">
-            <h1 />
-          </Localized>
-          <Localized id="profile-not-required">
-            <h2 />
-          </Localized>
-          <Localized id="sign-up-account">
-            <LinkButton
-              rounded
-              href="/login"
-              onClick={() => trackHome('click-benefits-register', locale)}
-            />
-          </Localized>
-        </RegisterSection>
-      )}
     </div>
   );
 }

--- a/web/src/components/pages/languages/languages.tsx
+++ b/web/src/components/pages/languages/languages.tsx
@@ -325,57 +325,13 @@ class LanguagesPage extends React.PureComponent<Props, State> {
                 : [1, 2, 3].map((n, i) => <LoadingLocalizationBox key={i} />)}
             </ul>
 
-            {!query && (
+            {!query && launched.length > 3 && (
               <Localized
                 id={'languages-show-' + (showAllLaunched ? 'less' : 'more')}>
                 <button
                   disabled={launched.length === 0}
                   className="show-all-languages"
                   onClick={this.toggleShowAllLaunched}
-                />
-              </Localized>
-            )}
-          </section>
-
-          <section className="in-progress">
-            <div className="md-block">
-              <div style={{ display: 'flex', flexDirection: 'row' }}>
-                <h1 style={{ marginRight: '1.5rem' }}>
-                  {getString('language-section-in-progress')}
-                  {inProgressCountLabel}
-                </h1>
-              </div>
-              <Hr />
-            </div>
-
-            <Localized
-              id="language-section-in-progress-new-description"
-              elems={descriptionElems}>
-              <p />
-            </Localized>
-            <ul>
-              {inProgress.length > 0
-                ? (query || showAllInProgress
-                    ? filteredInProgress
-                    : filteredInProgress.slice(0, 3)
-                  ).map((localization, i) => (
-                    <LocalizationBox
-                      key={localization.locale}
-                      localeMessages={localeMessages}
-                      type="in-progress"
-                      {...localization}
-                    />
-                  ))
-                : [1, 2, 3].map(i => <LoadingLocalizationBox key={i} />)}
-            </ul>
-
-            {!query && (
-              <Localized
-                id={'languages-show-' + (showAllInProgress ? 'less' : 'more')}>
-                <button
-                  disabled={inProgress.length === 0}
-                  className="show-all-languages"
-                  onClick={this.toggleShowAllInProgress}
                 />
               </Localized>
             )}

--- a/web/src/components/pages/profile/layout.tsx
+++ b/web/src/components/pages/profile/layout.tsx
@@ -19,7 +19,6 @@ import {
   UserPlusIcon,
 } from '../../ui/icons';
 import AvatarSetup from './avatar-setup/avatar-setup';
-import DeleteProfile from './delete/delete';
 import InfoPage from './info/info';
 import Settings from './settings/settings';
 
@@ -73,11 +72,10 @@ interface PropsFromState {
 interface Props extends LocalePropsFromState, PropsFromState {}
 
 const Layout = ({ toLocaleRoute, user }: Props) => {
-  const [infoRoute, avatarRoute, prefRoute, deleteRoute] = [
+  const [infoRoute, avatarRoute, prefRoute] = [
     URLS.PROFILE_INFO,
     URLS.PROFILE_AVATAR,
-    URLS.PROFILE_SETTINGS,
-    URLS.PROFILE_DELETE,
+    URLS.PROFILE_SETTINGS
   ].map(r => toLocaleRoute(r));
   return (
     <div className="profile-layout">
@@ -91,12 +89,7 @@ const Layout = ({ toLocaleRoute, user }: Props) => {
                 : { icon: <UserPlusIcon />, id: 'build-profile' }),
             },
             { route: avatarRoute, icon: <CameraIcon />, id: 'avatar' },
-            { route: prefRoute, icon: <CogIcon />, id: 'settings' },
-            {
-              route: deleteRoute,
-              icon: <TrashIcon />,
-              id: 'profile-form-delete',
-            },
+            { route: prefRoute, icon: <CogIcon />, id: 'settings' }
           ]
             .slice(0, user.account ? Infinity : 1)
             .map(({ route, icon, id }) => (
@@ -107,33 +100,13 @@ const Layout = ({ toLocaleRoute, user }: Props) => {
                 </Localized>
               </NavLink>
             ))}
-          {user.account && (
-            <a onClick={() => downloadData(user.account)} href="#">
-              <CloudIcon />
-              <Localized id="download-profile">
-                <span className="text" />
-              </Localized>
-            </a>
-          )}
         </div>
       </div>
       <div className="content">
         <Switch>
           <Route exact path={infoRoute} component={InfoPage} />
-          {[
-            { route: avatarRoute, Component: AvatarSetup },
-            { route: prefRoute, Component: Settings },
-            { route: deleteRoute, Component: DeleteProfile },
-          ].map(({ route, Component }) => (
-            <Route
-              key={route}
-              exact
-              path={route}
-              render={props =>
-                user.account ? <Component /> : <Redirect to={infoRoute} />
-              }
-            />
-          ))}
+          <Route exact path={avatarRoute} component={AvatarSetup} />
+          <Route exact path={prefRoute} component={Settings} />
           <Route
             render={() => <Redirect to={toLocaleRoute(URLS.PROFILE_INFO)} />}
           />


### PR DESCRIPTION
* Remove access to MZ content
* Remove in-progress languages, datasets/faq/about page
* Split listen/speak in header nav
* Remove delete profile + download data options from profile settings
* Default new accoutns to visible in leaderboard
* Redirect contribution pages to login if not already